### PR TITLE
fix message api construct

### DIFF
--- a/src/TreasureData/API/Message.php
+++ b/src/TreasureData/API/Message.php
@@ -28,6 +28,9 @@ abstract class TreasureData_API_Message
                 $comment = $property->getDocComment();
 
                 if (preg_match("/array<(.+)?>/", $comment, $match)) {
+                    if (!is_array($values[$name])) {
+                        continue;
+                    }
                     $class_name = $match[1];
                     if ($class_name == "TreasureData_API_Message_TableSchema") {
                         $schema = json_decode($values[$name], true);


### PR DESCRIPTION
GET /v3/job/show/:job_idのコマンドを投げた時に、
stautusがsuccess以外のrunningやerrorなどの状態の結果でdebug→cmdoutを取得したいのですが、
（http://docs.treasure-data.com/articles/rest-api#get-v3jobshowjobid）
TreasureData_API_Message_JobInformationのコンストラクタで$hive_result_schemaを作成するときに
中身がnullでエラーがでます。
その修正です。